### PR TITLE
chore(templates): Updating the body type names

### DIFF
--- a/pkg/codegen/apis/api/server.go
+++ b/pkg/codegen/apis/api/server.go
@@ -28,7 +28,7 @@ type ServerInterface interface {
 
 	// Upload a report
 	// UploadReport (POST /reports/upload)
-	UploadReport(l *slog.Logger, r *http.Request, body0 *UploadReportJSONBody) (*ReportDetails, error)
+	UploadReport(l *slog.Logger, r *http.Request, body0 *UploadReportRequestBody) (*ReportDetails, error)
 
 	// Get a report by hash
 	// GetReport (GET /reports/{hash})
@@ -271,7 +271,7 @@ func (siw *ServerInterfaceWrapper) UploadReport(w http.ResponseWriter, r *http.R
 		}
 	}()
 
-	body := &UploadReportJSONBody{
+	body := &UploadReportRequestBody{
 		File: new(openapi_types.File),
 	}
 

--- a/pkg/codegen/apis/api/types.go
+++ b/pkg/codegen/apis/api/types.go
@@ -220,4 +220,4 @@ type UploadReportFormdataBody struct {
 type UploadReportFormdataRequestBody UploadReportFormdataBody
 
 // Temporary inclusion of type alias for backwards compatibility
-type UploadReportJSONBody = UploadReportFormdataBody
+type UploadReportRequestBody = UploadReportFormdataBody

--- a/pkg/codegen/templates/gorilla/gorilla-interface.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-interface.tmpl
@@ -19,7 +19,7 @@ type ServerInterface interface {
 {{- if $c }}{{ $form = ", multipartForm map[string][]string" }}{{ end -}}
 {{- end }}
 {{- end }}
-{{$opid}}(l *slog.Logger, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{$opid}}Params{{end}}{{range $i, $b := .Bodies}}, body{{$i}} *{{$opid}}JSONBody{{end}}{{$form}}) ({{ $ret }}, error)
+{{$opid}}(l *slog.Logger, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params {{$opid}}Params{{end}}{{range $i, $b := .Bodies}}, body{{$i}} *{{$opid}}RequestBody{{end}}{{$form}}) ({{ $ret }}, error)
 {{end}}
 }
 
@@ -28,7 +28,7 @@ type ServerInterface interface {
 type ServerInterface interface {
   {{range .}}{{.SummaryAsComment }}{{$opid := .OperationId}}
   // ({{.Method}} {{.Path}})
-  {{.OperationId}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{.OperationId}}Params{{end}}{{range $i, $b := .Bodies}}{{if eq $b.ContentType "application/json"}}, body{{$i}} *{{$opid}}JSONBody{{end}}{{end}})
+  {{.OperationId}}(w http.ResponseWriter, r *http.Request{{genParamArgs .PathParams}}{{if .RequiresParamObject}}, params *{{.OperationId}}Params{{end}}{{range $i, $b := .Bodies}}{{if eq $b.ContentType "application/json"}}, body{{$i}} *{{$opid}}RequestBody{{end}}{{end}})
   {{end}}
 }
 */}}

--- a/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
@@ -248,7 +248,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   {{end}}
   {{else if eq $contentType "application/x-www-form-urlencoded" }}
   {{/* If the defined body is a file, then try and get the file into the expected type */}}
-  body := &{{$opid}}JSONBody{
+  body := &{{$opid}}RequestBody{
     File: new(openapi_types.File),
   }
 

--- a/pkg/codegen/templates/request-bodies.tmpl
+++ b/pkg/codegen/templates/request-bodies.tmpl
@@ -5,7 +5,7 @@
 // {{.TypeName}} defines body for {{$opid}} for {{$contentType}} ContentType.
 type {{.TypeName}} {{if .IsAlias}}={{end}} {{.Schema.TypeDecl}}
 {{- if ne (printf "%sJSONBody" $opid) .Schema.TypeDecl }}
-// Temporary inclusion of type alias for backwards compatibility
+// {{$opid}}RequestBody defines a new type that can be used to unmarshal {{$contentType}} request body.
 type {{$opid}}RequestBody = {{.Schema.TypeDecl}}
 {{- end }}
 {{end}}

--- a/pkg/codegen/templates/request-bodies.tmpl
+++ b/pkg/codegen/templates/request-bodies.tmpl
@@ -6,7 +6,7 @@
 type {{.TypeName}} {{if .IsAlias}}={{end}} {{.Schema.TypeDecl}}
 {{- if ne (printf "%sJSONBody" $opid) .Schema.TypeDecl }}
 // Temporary inclusion of type alias for backwards compatibility
-type {{$opid}}JSONBody = {{.Schema.TypeDecl}}
+type {{$opid}}RequestBody = {{.Schema.TypeDecl}}
 {{- end }}
 {{end}}
 {{end}}

--- a/pkg/services/api/upload.go
+++ b/pkg/services/api/upload.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jacobbrewer1/utils"
 )
 
-func (s *service) UploadReport(l *slog.Logger, r *http.Request, body0 *api.UploadReportJSONBody) (*api.ReportDetails, error) {
+func (s *service) UploadReport(l *slog.Logger, r *http.Request, body0 *api.UploadReportRequestBody) (*api.ReportDetails, error) {
 	bts, err := body0.File.Bytes()
 	if err != nil {
 		return nil, uhttp.NewHTTPError(http.StatusBadRequest, err, "error reading file")


### PR DESCRIPTION
This pull request includes several updates to the `ServerInterface` and related files to rename the request body type from `UploadReportJSONBody` to `UploadReportRequestBody` for consistency and clarity. The most important changes include updates to interface definitions, type aliases, and function parameters.

Changes to interface definitions and function parameters:

* [`pkg/codegen/apis/api/server.go`](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fL31-R31): Updated `ServerInterface` to use `UploadReportRequestBody` instead of `UploadReportJSONBody` in the `UploadReport` method.
* [`pkg/codegen/templates/gorilla/gorilla-interface.tmpl`](diffhunk://#diff-656e5237c66ca49cfc7d8a7d393efbbf8d369b2b9885eaa5d437652bae348372L22-R22): Changed the interface methods to use `UploadReportRequestBody` instead of `UploadReportJSONBody`. [[1]](diffhunk://#diff-656e5237c66ca49cfc7d8a7d393efbbf8d369b2b9885eaa5d437652bae348372L22-R22) [[2]](diffhunk://#diff-656e5237c66ca49cfc7d8a7d393efbbf8d369b2b9885eaa5d437652bae348372L31-R31)

Changes to type aliases:

* [`pkg/codegen/apis/api/types.go`](diffhunk://#diff-d9512cf9b09d854854899cd5e11551839abf325f4a44a069c96aa003c30ac112L223-R223): Renamed the type alias from `UploadReportJSONBody` to `UploadReportRequestBody` for backwards compatibility.
* [`pkg/codegen/templates/request-bodies.tmpl`](diffhunk://#diff-9df37d9af3f9148fb7deba8c03a3341f91df35eaa6e6c4813eda3e0698073288L8-R9): Updated the template to define `UploadReportRequestBody` instead of `UploadReportJSONBody`.

Changes to function implementations:

* [`pkg/codegen/apis/api/server.go`](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fL274-R274): Updated the `UploadReport` method in `ServerInterfaceWrapper` to use `UploadReportRequestBody`.
* [`pkg/codegen/templates/gorilla/gorilla-middleware.tmpl`](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cL251-R251): Modified the middleware template to use `UploadReportRequestBody` instead of `UploadReportJSONBody`.
* [`pkg/services/api/upload.go`](diffhunk://#diff-8796a9bdc05933f315de5ca0e147d1bf82890993e60a2dd7365e41afd69915edL17-R17): Changed the `UploadReport` method to use `UploadReportRequestBody`.