### PR TITLE
fix(reports): Using enum values on the db that reflect the api spec

### DIFF
--- a/database/migrations/20250117083222_lowercase_enums.down.sql
+++ b/database/migrations/20250117083222_lowercase_enums.down.sql
@@ -1,0 +1,1 @@
+alter table resource modify column status enum ('SKIPPED', 'CHANGED', 'FAILED', 'UNCHANGED') not null;

--- a/database/migrations/20250117083222_lowercase_enums.up.sql
+++ b/database/migrations/20250117083222_lowercase_enums.up.sql
@@ -1,0 +1,1 @@
+alter table resource modify column status enum ('skipped', 'changed', 'failed', 'unchanged') not null;

--- a/database/migrations/20250117083601_report_state_enums.down.sql
+++ b/database/migrations/20250117083601_report_state_enums.down.sql
@@ -1,0 +1,1 @@
+alter table report modify column state text not null;

--- a/database/migrations/20250117083601_report_state_enums.up.sql
+++ b/database/migrations/20250117083601_report_state_enums.up.sql
@@ -1,0 +1,1 @@
+alter table report modify column state enum ('changed', 'failed', 'unchanged') not null;

--- a/pkg/services/api/reports.go
+++ b/pkg/services/api/reports.go
@@ -102,9 +102,9 @@ func (s *service) GetReport(l *slog.Logger, r *http.Request, hash string) (*api.
 	if err != nil {
 		switch {
 		case errors.Is(err, repo.ErrReportNotFound):
-			return nil, uhttp.NewHTTPError(http.StatusNotFound, err, "report not found")
+			return nil, uhttp.NewHTTPError(http.StatusNotFound, err, "report not found", fmt.Sprintf("hash: %s", hash))
 		default:
-			return nil, uhttp.NewHTTPError(http.StatusInternalServerError, err, "failed to get report")
+			return nil, uhttp.NewHTTPError(http.StatusInternalServerError, err, "failed to get report", fmt.Sprintf("hash: %s", hash))
 		}
 	}
 


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes changes to database migrations and error handling in the `GetReport` function. The most important changes are as follows:

Database migrations:

* [`database/migrations/20250117083222_lowercase_enums.up.sql`](diffhunk://#diff-a3ae067aebc7d36a24561e7047033405527763692412812b346a08b013b5ee50R1): Modified the `status` column in the `resource` table to use lowercase enum values.
* [`database/migrations/20250117083222_lowercase_enums.down.sql`](diffhunk://#diff-80ca2bf2bced5d753ac06bb2a39cc9a202675e1fd9705e01d1cddc1f9c61bfc1R1): Modified the `status` column in the `resource` table to use uppercase enum values.
* [`database/migrations/20250117083601_report_state_enums.up.sql`](diffhunk://#diff-4a0138cdbc4c7cec8350500fb22e5e1af11596e0e02c1e03d029adcbc382f328R1): Changed the `state` column in the `report` table to use enum values.
* [`database/migrations/20250117083601_report_state_enums.down.sql`](diffhunk://#diff-7d84d0308a1e63ecdf2f939e65b582ea0f768e850af3c85a6e0cee78c2f9ae0aR1): Changed the `state` column in the `report` table to use text values.

Error handling:

* [`pkg/services/api/reports.go`](diffhunk://#diff-9dfba7ce690de7af95f2217972cfc13d9517999c3e1a4c0a1e15c4a92402aa88L105-R107): Enhanced error messages in the `GetReport` function to include the `hash` value when a report is not found or when failing to get a report.