### PR TITLE
feat(templates): Parsing requests with a single method in the templates

### DIFF
--- a/pkg/codegen/apis/api/client.go
+++ b/pkg/codegen/apis/api/client.go
@@ -362,7 +362,7 @@ func NewUploadReportRequestWithBody(server string, contentType string, body io.R
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/reports/upload")
+	operationPath := fmt.Sprintf("/reports")
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}

--- a/pkg/codegen/apis/api/routes.yaml
+++ b/pkg/codegen/apis/api/routes.yaml
@@ -10,6 +10,39 @@ tags:
 
 paths:
   /reports:
+    post:
+      operationId: uploadReport
+      tags:
+        - reports
+      summary: Upload a report
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '201':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/report_details'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '../../../../vendor/github.com/jacobbrewer1/uhttp/common/common.yaml#/components/schemas/error_message'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '../../../../vendor/github.com/jacobbrewer1/uhttp/common/common.yaml#/components/schemas/error_message'
     get:
       operationId: getReports
       tags:
@@ -74,41 +107,6 @@ paths:
                 $ref: '../../../../vendor/github.com/jacobbrewer1/uhttp/common/common.yaml#/components/schemas/error_message'
         '404':
           description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '../../../../vendor/github.com/jacobbrewer1/uhttp/common/common.yaml#/components/schemas/error_message'
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: '../../../../vendor/github.com/jacobbrewer1/uhttp/common/common.yaml#/components/schemas/error_message'
-
-  /reports/upload:
-    post:
-      operationId: uploadReport
-      tags:
-        - reports
-      summary: Upload a report
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: object
-              properties:
-                file:
-                  type: string
-                  format: binary
-      responses:
-        '201':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/report_details'
-        '400':
-          description: Bad Request
           content:
             application/json:
               schema:

--- a/pkg/codegen/apis/api/server.go
+++ b/pkg/codegen/apis/api/server.go
@@ -389,7 +389,7 @@ func (siw *ServerInterfaceWrapper) parseRequestBody(r *http.Request, dest any) e
 
 		body.InitFromBytes(bdy, "file")
 	default:
-		return http.ErrNotSupported
+		return &UnsupportedContentTypeError{ContentType: contentType}
 	}
 
 	return nil
@@ -451,6 +451,18 @@ func (e *UnescapedCookieParamError) Error() string {
 
 func (e *UnescapedCookieParamError) Unwrap() error {
 	return e.Err
+}
+
+type UnsupportedContentTypeError struct {
+	ContentType string
+}
+
+func (e *UnsupportedContentTypeError) StatusCode() int {
+	return http.StatusUnsupportedMediaType
+}
+
+func (e *UnsupportedContentTypeError) Error() string {
+	return fmt.Sprintf("Unsupported content type: %s", e.ContentType)
 }
 
 type UnmarshalingBodyError struct {

--- a/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
@@ -13,6 +13,7 @@ type ServerInterfaceWrapper struct {
     rateLimiter RateLimiterFunc
     metricsMiddleware MetricsMiddlewareFunc
     errorHandlerFunc ErrorHandlerFunc
+    isInternalAPI bool
 }
 
 // WithAuthorization applies the passed authorization middleware to the server.
@@ -40,6 +41,13 @@ func WithErrorHandlerFunc(errorHandlerFunc ErrorHandlerFunc) ServerOption {
 func WithMetricsMiddleware(middleware MetricsMiddlewareFunc) ServerOption {
     return func(s *ServerInterfaceWrapper) {
         s.metricsMiddleware = middleware
+    }
+}
+
+// WithInternalAPI sets the server as an internal API.
+func WithInternalAPI(isInternalAPI bool) ServerOption {
+    return func(s *ServerInterfaceWrapper) {
+        s.isInternalAPI = isInternalAPI
     }
 }
 
@@ -239,24 +247,21 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   {{with .TypeDef $opid}}
     // ------------- Body parameter for {{$opid}} for {{$contentType}} ContentType -------------
     body := new({{.TypeName}})
-    if err := json.NewDecoder(r.Body).Decode(body); err != nil {
-       siw.errorHandlerFunc(cw, ctx, &UnmarshalingParamError{ParamName: "body", Err: err})
-       return
+    if err := siw.parseRequestBody(r, body); err != nil {
+        siw.errorHandlerFunc(cw, ctx, err)
+        return
     }
   {{end}}
   {{else if eq $contentType "application/x-www-form-urlencoded" }}
   {{/* If the defined body is a file, then try and get the file into the expected type */}}
-  body := &{{$opid}}RequestBody{
-    File: new(openapi_types.File),
-  }
+    body := &{{$opid}}RequestBody{
+      File: new(openapi_types.File),
+    }
 
-  bdy, err := io.ReadAll(r.Body)
-  if err != nil {
-    siw.errorHandlerFunc(cw, ctx, &UnmarshalingParamError{ParamName: "body", Err: err})
-    return
-  }
-
-  body.File.InitFromBytes(bdy, "file")
+    if err := siw.parseRequestBody(r, body.File); err != nil {
+        siw.errorHandlerFunc(cw, ctx, err)
+        return
+    }
   {{end}}
   {{end}}
 
@@ -308,6 +313,41 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
   }
 }
 {{end}}
+
+// parseRequestBody parses the request body into the expected type.
+func (siw *ServerInterfaceWrapper) parseRequestBody(r *http.Request, dest any) error {
+    if r.Body == http.NoBody {
+        return nil
+    }
+
+    contentType := r.Header.Get(uhttp.HeaderContentType)
+    switch contentType {
+    case "application/json":
+        decoder := json.NewDecoder(r.Body)
+        if !siw.isInternalAPI {
+            decoder.DisallowUnknownFields()
+        }
+        if err := decoder.Decode(dest); err != nil {
+            return &UnmarshalingBodyError{ExpectedType: "application/json", Err: err}
+        }
+    case "application/x-www-form-urlencoded":
+        bdy, err := io.ReadAll(r.Body)
+        if err != nil {
+          return &UnmarshalingBodyError{ExpectedType: "application/x-www-form-urlencoded", Err: err}
+        }
+
+        body, ok := dest.(*openapi_types.File)
+        if !ok {
+            return &UnmarshalingBodyError{ExpectedType: "application/x-www-form-urlencoded", Err: fmt.Errorf("expected *openapi_types.FormData, got %T", dest)}
+        }
+
+        body.InitFromBytes(bdy, "file")
+    default:
+        return http.ErrNotSupported
+    }
+
+    return nil
+}
 
 // handleError handles returning a correctly-formatted error to the API caller.
 func handleError(w http.ResponseWriter, ctx context.Context, err error) {
@@ -365,6 +405,19 @@ func (e *UnescapedCookieParamError) Error() string {
 
 func (e *UnescapedCookieParamError) Unwrap() error {
     return e.Err
+}
+
+type UnmarshalingBodyError struct {
+    ExpectedType string
+    Err error
+}
+
+func (e *UnmarshalingBodyError) StatusCode() int {
+    return http.StatusBadRequest
+}
+
+func (e *UnmarshalingBodyError) Error() string {
+    return fmt.Sprintf("Error unmarshaling request body as %s: %s", e.ExpectedType, e.Err.Error())
 }
 
 type UnmarshalingParamError struct {

--- a/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
@@ -343,7 +343,7 @@ func (siw *ServerInterfaceWrapper) parseRequestBody(r *http.Request, dest any) e
 
         body.InitFromBytes(bdy, "file")
     default:
-        return http.ErrNotSupported
+        return &UnsupportedContentTypeError{ContentType: contentType}
     }
 
     return nil
@@ -405,6 +405,18 @@ func (e *UnescapedCookieParamError) Error() string {
 
 func (e *UnescapedCookieParamError) Unwrap() error {
     return e.Err
+}
+
+type UnsupportedContentTypeError struct {
+    ContentType string
+}
+
+func (e *UnsupportedContentTypeError) StatusCode() int {
+    return http.StatusUnsupportedMediaType
+}
+
+func (e *UnsupportedContentTypeError) Error() string {
+    return fmt.Sprintf("Unsupported content type: %s", e.ContentType)
 }
 
 type UnmarshalingBodyError struct {

--- a/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
+++ b/pkg/codegen/templates/gorilla/gorilla-middleware.tmpl
@@ -317,7 +317,7 @@ func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Requ
 // parseRequestBody parses the request body into the expected type.
 func (siw *ServerInterfaceWrapper) parseRequestBody(r *http.Request, dest any) error {
     if r.Body == http.NoBody {
-        return nil
+        return &UnmarshalingBodyError{Err: errors.New("empty body")}
     }
 
     contentType := r.Header.Get(uhttp.HeaderContentType)
@@ -328,17 +328,17 @@ func (siw *ServerInterfaceWrapper) parseRequestBody(r *http.Request, dest any) e
             decoder.DisallowUnknownFields()
         }
         if err := decoder.Decode(dest); err != nil {
-            return &UnmarshalingBodyError{ExpectedType: "application/json", Err: err}
+            return &UnmarshalingBodyError{Err: err}
         }
     case "application/x-www-form-urlencoded":
         bdy, err := io.ReadAll(r.Body)
         if err != nil {
-          return &UnmarshalingBodyError{ExpectedType: "application/x-www-form-urlencoded", Err: err}
+          return &UnmarshalingBodyError{Err: err}
         }
 
         body, ok := dest.(*openapi_types.File)
         if !ok {
-            return &UnmarshalingBodyError{ExpectedType: "application/x-www-form-urlencoded", Err: fmt.Errorf("expected *openapi_types.FormData, got %T", dest)}
+            return &UnmarshalingBodyError{Err: fmt.Errorf("expected *openapi_types.FormData, got %T", dest)}
         }
 
         body.InitFromBytes(bdy, "file")
@@ -420,7 +420,6 @@ func (e *UnsupportedContentTypeError) Error() string {
 }
 
 type UnmarshalingBodyError struct {
-    ExpectedType string
     Err error
 }
 
@@ -429,7 +428,7 @@ func (e *UnmarshalingBodyError) StatusCode() int {
 }
 
 func (e *UnmarshalingBodyError) Error() string {
-    return fmt.Sprintf("Error unmarshaling request body as %s: %s", e.ExpectedType, e.Err.Error())
+    return fmt.Sprintf("Error unmarshaling request body: %s", e.Err.Error())
 }
 
 type UnmarshalingParamError struct {


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request introduces several changes to improve the handling of request bodies in the server interface and middleware templates. The primary aim is to add support for internal APIs and enhance error handling for unsupported content types and unmarshaling errors.

Enhancements to server interface and middleware:

* Added a new `isInternalAPI` boolean field to the `ServerInterfaceWrapper` struct to indicate whether the server is handling internal APIs. (`pkg/codegen/apis/api/server.go`, `pkg/codegen/templates/gorilla/gorilla-middleware.tmpl`) [[1]](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fR53) [[2]](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cR16)
* Introduced a new `WithInternalAPI` function to set the `isInternalAPI` field in the `ServerInterfaceWrapper` struct. (`pkg/codegen/apis/api/server.go`, `pkg/codegen/templates/gorilla/gorilla-middleware.tmpl`) [[1]](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fR84-R90) [[2]](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cR47-R53)

Improved request body parsing:

* Refactored the `UploadReport` and `GetReport` methods to use a new `parseRequestBody` helper function for parsing request bodies based on content type. (`pkg/codegen/apis/api/server.go`, `pkg/codegen/templates/gorilla/gorilla-middleware.tmpl`) [[1]](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fL278-L285) [[2]](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fR363-R397) [[3]](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cL242-R251) [[4]](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cL253-L259) [[5]](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cR317-R351)

Enhanced error handling:

* Added new error types `UnsupportedContentTypeError` and `UnmarshalingBodyError` to handle unsupported content types and errors during request body unmarshaling. (`pkg/codegen/apis/api/server.go`, `pkg/codegen/templates/gorilla/gorilla-middleware.tmpl`) [[1]](diffhunk://#diff-46b5b7475ff2ecf8903a1e8b071da363a1943cee6665aae3a99b328496a7fe7fR456-R480) [[2]](diffhunk://#diff-8d69a7a5bfef27704007906301314ffc4d8d1c3c3063ec8813934f9a877a1d6cR410-R434)