### PR TITLE
fix(web): Enabling the next pagination button after search

### DIFF
--- a/pkg/services/web/templates/index.gohtml
+++ b/pkg/services/web/templates/index.gohtml
@@ -177,6 +177,9 @@
 
         // Ensure the search form triggers fetchReports on submission
         document.addEventListener('htmx:afterRequest', function (evt) {
+            // Enable the next page button after a search request
+            document.getElementById("next-page").disabled = false;
+
             if (evt.target.id === "report-search-form") {
                 // Update the total report count after the search request
                 let searchParams = getSearchParams(); // Get search parameters from the form


### PR DESCRIPTION
## Describe your changes

<!--- A clear and concise description of what the changes are. -->

This pull request includes a small change to the `pkg/services/web/templates/index.gohtml` file. The change ensures that the "next page" button is enabled after a search request.

* [`pkg/services/web/templates/index.gohtml`](diffhunk://#diff-793160fbb6c2a95f02838ec33f23262dd37c806b9a5d2333f0f642a0e7f58956R180-R182): Added code to enable the "next page" button after a search request.